### PR TITLE
feat: add manual workflow dispatch trigger to CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,7 @@
 name: CD
 
 on:
+  workflow_dispatch:  # Allow manual triggering
   push:
     branches:
       - main


### PR DESCRIPTION
- Allows manually triggering release workflow from GitHub Actions UI
- Useful for forcing releases after workflow-only changes
- Maintains all existing automatic triggers