### PR TITLE
fix: move PR number parsing to env variable

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,14 +39,13 @@ jobs:
       # Auto-merge release PRs after checks pass
       - name: Enable auto-merge for release PR
         if: ${{ steps.release.outputs.pr }}
-        run: |
-          echo "PR output: ${{ toJSON(steps.release.outputs.pr) }}"
-          PR_NUMBER=${{ fromJSON(steps.release.outputs.pr).number }}
-          echo "Enabling auto-merge for PR #${PR_NUMBER}"
-          gh pr merge ${PR_NUMBER} --auto --merge
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+        run: |
+          echo "Enabling auto-merge for PR #${PR_NUMBER}"
+          gh pr merge ${PR_NUMBER} --auto --merge
 
   build-and-upload:
     needs: release-please


### PR DESCRIPTION
- Parse PR number using fromJSON in env section
- Avoids bash syntax errors with complex JSON parsing
- PR number is cleanly available as environment variable